### PR TITLE
Add Main Layout

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,6 +5,7 @@
       "name": "frontend",
       "dependencies": {
         "@tailwindcss/vite": "^4.0.14",
+        "clsx": "^2.1.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.3.0",
@@ -248,6 +249,8 @@
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     },
     "dependencies": {
         "@tailwindcss/vite": "^4.0.14",
+        "clsx": "^2.1.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.3.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,14 +4,13 @@ import {
     RouterProvider,
 } from 'react-router-dom';
 import MainLayout from './layouts/MainLayout';
+import Home from './pages/Home';
 
 const routes: RouteObject[] = [
     {
         path: '/',
         element: <MainLayout />,
-        children: [
-            // { path: '', element: <Home /> }
-        ],
+        children: [{ path: '', element: <Home /> }],
     },
 ];
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,24 @@
+const Header = ({
+    setShowSideBar,
+}: {
+    setShowSideBar: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
+    return (
+        <div className="flex">
+            Header
+            <span className="md:hidden">
+                <svg
+                    className="w-8 h-8"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    onClick={() => setShowSideBar((p) => !p)}
+                >
+                    <path d="M3 4H21V6H3V4ZM3 11H21V13H3V11ZM3 18H21V20H3V18Z"></path>
+                </svg>
+            </span>
+        </div>
+    );
+};
+
+export default Header;

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,5 @@
+const Sidebar = () => {
+    return <div className="">Sidebar</div>;
+};
+
+export default Sidebar;

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -1,5 +1,36 @@
+import { Outlet } from 'react-router-dom';
+import Sidebar from '../components/Sidebar';
+import Header from '../components/Header';
+import { useState } from 'react';
+import clsx from 'clsx';
+
 const MainLayout = () => {
-    return <div>MainLayout</div>;
+    const [showSideBar, setShowSideBar] = useState(false);
+
+    const asideClasses = clsx(
+        'w-[80dvw] absolute left-0 top-0 md:static md:w-full md:col-span-2 z-20 h-full overflow-y-auto',
+        {
+            block: showSideBar,
+            hidden: !showSideBar,
+            'md:block': true,
+        }
+    );
+
+    return (
+        <div className="w-dvw h-dvh flex flex-col overflow-hidden">
+            <header className="w-full sticky top-0 left-0 z-50">
+                <Header setShowSideBar={setShowSideBar} />
+            </header>
+            <div className="main w-full grid grid-cols-12 h-full overflow-hidden relative">
+                <aside className={asideClasses}>
+                    <Sidebar />
+                </aside>
+                <main className=" w-full col-span-12 md:col-span-10 h-full overflow-y-auto z-10">
+                    <Outlet />
+                </main>
+            </div>
+        </div>
+    );
 };
 
 export default MainLayout;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,0 +1,5 @@
+const Home = () => {
+    return <div className="">Home</div>;
+};
+
+export default Home;


### PR DESCRIPTION
# Pull Request: Add Main Layout Component

## Overview
This PR introduces a new `MainLayout` component that provides a consistent structure for the application, featuring a sticky header, a toggleable sidebar, and a main content area.

## Changes
- Created `MainLayout` with:
  - Sticky header
  - Sidebar for navigation (toggleable on smaller screens)
  - Main content area using `Outlet` from `react-router-dom`
- Utilized Tailwind CSS for responsive styling.

## Benefits
- Improved user experience with organized navigation.
- Modular design for better maintainability.
- Responsive layout for various screen sizes.

## Testing
- Verify the layout renders correctly across devices.
- Test sidebar toggle functionality.